### PR TITLE
Add instrument log to Pruth Mooring

### DIFF
--- a/instrument-log.csv
+++ b/instrument-log.csv
@@ -1,5 +1,5 @@
 instrument_manufacturer,instrument_model,instrument_sn,station,fixed_depth,deployment_time,comment,correction,db_table,table_type
-Onset,Tidbit,20187017,Pruth,0.3,2017-12-02T00:00:00 +00:00,,,pruth_mooring_0_3m,temperature
+Onset,Tidbit,20187017,Pruth,0.3,2017-12-02T00:00:00 +00:00,,,pruth_mooring_0m,temperature
 Onset,Tidbit,20187018,Pruth,2,2017-12-02T00:00:00 +00:00,,,pruth_mooring_2m,temperature
 Onset,Tidbit,20187019,Pruth,5,2017-12-02T00:00:00 +00:00,,,pruth_mooring_5m,temperature
 Onset,Tidbit,20187020,Pruth,7.5,2017-12-02T00:00:00 +00:00,,,pruth_mooring_7_5m,temperature


### PR DESCRIPTION
Add instrument log within Pruth Mooring repo. This log is used by the new python tool to upload instrument data and their associated depth to the hakai database